### PR TITLE
Modify FoldersTest to class so that tests run

### DIFF
--- a/autoz/src/test/scala/autolift/FoldersTest.scala
+++ b/autoz/src/test/scala/autolift/FoldersTest.scala
@@ -5,7 +5,7 @@ import scalaz._
 import Scalaz._
 import AutoLift._
 
-trait FoldersTest extends FlatSpec{
+class FoldersTest extends FlatSpec{
 	def same[A](x: A, y: A) = assert(x == y)
 
 	val s2i = {x: String => x.toInt }


### PR DESCRIPTION
When defined as a `trait`, scalatest won't get picked up and run by sbt test runner.
Modifying the test to a `class` ensures that it runs.
