### PR TITLE
resolvers for export-hook are missing in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ The current released branch is 0.4 and compiled against Scala version 2.11. If u
 
 ```scala
 libraryDependencies += "com.github.wheaties" %% "autolift-[backend]" % "0.4"
+
+resolvers ++= Seq(
+  Resolver.sonatypeRepo("releases"),
+  Resolver.sonatypeRepo("snapshots")
+)
 ```
 
 where "backend" is one of *algebird*, *cats* or *scalaz*. As stated above, *core* will be downloaded as a dependency.


### PR DESCRIPTION
I needed to add the resolvers for export-hook: https://github.com/milessabin/export-hook#using-export-hook

May this isn't the right solution and the additional resolvers should be added. I not sure.
