### PR TITLE
Better Scala-REPL for Scalaz sub-project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,47 +10,39 @@ lazy val root = (project in file(".")).settings(
 .aggregate(core, autoAlge, autoScalaz, autoCats, docs)
 
 lazy val core = build("autolift-core", "autolift-core").settings(
-  libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "2.2.1" % "test"
-  ),
-  scalacOptions += "-Ywarn-unused-import",
-  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genCore),
-  sonatypeProfileName := "wheaties"
+  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genCore)
 )
 
 lazy val autoCats = build("autolift-cats", "autolift-cats").settings(
   libraryDependencies ++= Seq(
     "org.spire-math" %% "cats" % "0.3.0",
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3"),
-    "org.scalatest" %% "scalatest" % "2.2.1" % "test"
+    compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
   ),
-  scalacOptions += "-Ywarn-unused-import",
-  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genCats),
-  sonatypeProfileName := "wheaties"
+  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genCats)
 )
   .dependsOn(core)
 
 lazy val autoAlge = build("autolift-algebird", "autolift-algebird").settings(
   libraryDependencies ++= Seq(
     "com.twitter" %% "algebird-core" % "0.11.0",
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3"),
-    "org.scalatest" %% "scalatest" % "2.2.1" % "test"
+    compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
   ),
-  scalacOptions += "-Ywarn-unused-import",
-  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genAlgebird),
-  sonatypeProfileName := "wheaties"
+  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genAlgebird)
 )
 .dependsOn(core)
 
 lazy val autoScalaz = build("autolift-scalaz", "autolift-scalaz").settings(
   libraryDependencies ++= Seq(
     "org.scalaz" %% "scalaz-core" % ScalaZ,
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3"),
-    "org.scalatest" %% "scalatest" % "2.2.1" % "test"
+    compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
   ),
-  scalacOptions += "-Ywarn-unused-import",
-  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genScalaz),
-  sonatypeProfileName := "wheaties"
+  initialCommands in console := """
+    import scalaz._
+    import scalaz.Scalaz._
+    import autolift.scalaz._
+    import autolift.Scalaz._
+  """,
+  sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genScalaz)
 )
 .dependsOn(core)
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,11 @@ lazy val autoCats = module("autolift-cats").settings(
     "org.spire-math" %% "cats" % "0.3.0",
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
   ),
+  initialCommands in console := """
+    import cats._
+    import cats.implicits._
+    import autolift.Cats._
+  """,
   sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genCats)
 )
   .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -9,11 +9,11 @@ lazy val root = (project in file(".")).settings(
 )
 .aggregate(core, autoAlge, autoScalaz, autoCats, docs)
 
-lazy val core = build("autolift-core", "autolift-core").settings(
+lazy val core = module("autolift-core").settings(
   sourceGenerators in Compile <+= (sourceManaged in Compile).map(Boilerplate.genCore)
 )
 
-lazy val autoCats = build("autolift-cats", "autolift-cats").settings(
+lazy val autoCats = module("autolift-cats").settings(
   libraryDependencies ++= Seq(
     "org.spire-math" %% "cats" % "0.3.0",
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
@@ -22,7 +22,7 @@ lazy val autoCats = build("autolift-cats", "autolift-cats").settings(
 )
   .dependsOn(core)
 
-lazy val autoAlge = build("autolift-algebird", "autolift-algebird").settings(
+lazy val autoAlge = module("autolift-algebird").settings(
   libraryDependencies ++= Seq(
     "com.twitter" %% "algebird-core" % "0.11.0",
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
@@ -31,7 +31,7 @@ lazy val autoAlge = build("autolift-algebird", "autolift-algebird").settings(
 )
 .dependsOn(core)
 
-lazy val autoScalaz = build("autolift-scalaz", "autolift-scalaz").settings(
+lazy val autoScalaz = module("autolift-scalaz").settings(
   libraryDependencies ++= Seq(
     "org.scalaz" %% "scalaz-core" % ScalaZ,
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")

--- a/project/AutoLift.scala
+++ b/project/AutoLift.scala
@@ -7,6 +7,23 @@ object AutoLift{
 	val ScalaVersion = "2.11.7"
 	val ScalaZ = "7.2.0"
 
+  def module(name: String) =
+    build(name, name).
+    settings(
+      scalacOptions ++= Seq(
+        "-Xfatal-warnings",
+        "-Ywarn-unused-import"
+      ),
+      scalacOptions in (Compile, console) ~= { defaultOptions =>
+        val unwantedOptions = Set("-Ywarn-unused-import", "-Xfatal-warnings")
+        defaultOptions filterNot unwantedOptions
+      },
+      libraryDependencies ++= Seq(
+        "org.scalatest" %% "scalatest" % "2.2.1" % "test"
+      ),
+      sonatypeProfileName := "wheaties"
+    )
+
   def build(pjName: String, base: String) = Project(
     id = pjName,
     base = file(base),
@@ -22,21 +39,11 @@ object AutoLift{
           "-language:higherKinds",
           "-language:existentials",
           "-unchecked",
-          "-Xfatal-warnings",
           "-Yno-adapted-args",
           "-Ywarn-dead-code",
           "-Ywarn-value-discard",
-          "-Xfuture",
-          "-Ywarn-unused-import"),
-        scalacOptions in (Compile, console) ~= { defaultOptions =>
-          val unwantedOptions = Set("-Ywarn-unused-import", "-Xfatal-warnings")
-          defaultOptions filterNot unwantedOptions
-        },
-        libraryDependencies ++= Seq(
-          "org.scalatest" %% "scalatest" % "2.2.1" % "test"
-        ),
+          "-Xfuture"),
         pomExtra := autoliftPom,
-        sonatypeProfileName := "wheaties",
         publishTo <<= version { v: String =>
           val nexus = "https://oss.sonatype.org/"
           if (v.trim.endsWith("SNAPSHOT"))

--- a/project/AutoLift.scala
+++ b/project/AutoLift.scala
@@ -1,6 +1,7 @@
 import sbt._
 import sbt.Keys._
 import xerial.sbt.Sonatype._
+import xerial.sbt.Sonatype.SonatypeKeys._
 
 object AutoLift{
 	val ScalaVersion = "2.11.7"
@@ -25,8 +26,17 @@ object AutoLift{
           "-Yno-adapted-args",
           "-Ywarn-dead-code",
           "-Ywarn-value-discard",
-          "-Xfuture"),
+          "-Xfuture",
+          "-Ywarn-unused-import"),
+        scalacOptions in (Compile, console) ~= { defaultOptions =>
+          val unwantedOptions = Set("-Ywarn-unused-import", "-Xfatal-warnings")
+          defaultOptions filterNot unwantedOptions
+        },
+        libraryDependencies ++= Seq(
+          "org.scalatest" %% "scalatest" % "2.2.1" % "test"
+        ),
         pomExtra := autoliftPom,
+        sonatypeProfileName := "wheaties",
         publishTo <<= version { v: String =>
           val nexus = "https://oss.sonatype.org/"
           if (v.trim.endsWith("SNAPSHOT"))
@@ -66,3 +76,4 @@ object AutoLift{
         </developer>
       </developers>
 }
+


### PR DESCRIPTION
Add setting for the console task in sbt for a better REPL. Allows now:

```
$ sbt autolift-scalaz/console
Detected sbt version 0.13.9
[info] Starting scala interpreter...
[info] 
import scalaz._
import scalaz.Scalaz._
import autolift.scalaz._
import autolift.Scalaz._
Welcome to Scala version 2.11.7 (OpenJDK 64-Bit Server VM, Java 1.8.0_66-internal).

scala> List(None, Some(1)) liftMap { i: Int => i.toString }
res0: List[Option[String]] = List(None, Some(1))
```

(example is shortened)

Bevore the scalac options -Ywarn-unused-import and -Xfatal-warnings make it very difficult to use the REPL.

This makes it pretty easy to test some ideas. What imports should be added for cats and algebird?

At the same time I pulled common settings into project/AutoLift.scala
